### PR TITLE
fix version URL

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -1,13 +1,13 @@
 $name = "pack-repo"
 $version = "canary"
-$url = "https://github.com/draftcreate/draft-$name/releases/download/$version/$name-$version-windows-amd64.zip"
+$url = "https://github.com/draftcreate/draft-$name/releases/download/$version/$name-v$version-windows-amd64.zip"
 
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'
 }
 $tempDir = Join-Path $env:TEMP $name
 if (![System.IO.Directory]::Exists($tempDir)) {[void][System.IO.Directory]::CreateDirectory($tempDir)}
-$file = Join-Path $env:TEMP "$name-$version-windows-amd64.zip"
+$file = Join-Path $env:TEMP "$name-v$version-windows-amd64.zip"
 
 Write-Output "Downloading $url"
 (new-object System.Net.WebClient).DownloadFile($url, $file)

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -77,7 +77,7 @@ verifySupported() {
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
-  DOWNLOAD_URL="https://azuredraft.blob.core.windows.net/draft/pack-repo-$DRAFT_PLUGIN_VERSION-$OS-$ARCH.tar.gz"
+  DOWNLOAD_URL="https://azuredraft.blob.core.windows.net/draft/pack-repo-v$DRAFT_PLUGIN_VERSION-$OS-$ARCH.tar.gz"
 }
 
 # downloadFile downloads the latest binary package and also the checksum


### PR DESCRIPTION
DRAFT_PLUGIN_VERSION is set to "0.4.0" as per plugin.yaml. We need to append a "v" to
fetch the right version.

we'll need to cut a v0.4.1 with this fix. Sorry everyone!